### PR TITLE
load playbooks from local filesystem instead of GitHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,3 @@
-# ── GitHub ────────────────────────────────────────────────────────────────────
-# Personal access token or fine-grained token with repo read access
-GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Repository that stores the playbook YAML files (owner/repo format)
-GITHUB_REPO=your-org/your-repo
-
 # ── Google Gemini AI ──────────────────────────────────────────────────────────
 # API key from Google AI Studio (aistudio.google.com)
 GEMINI_API_KEY=AIzaSy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -38,3 +31,13 @@ GRAFANA_TOKEN=glsa_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Publicly accessible Grafana dashboard URL used for screenshots
 GRAFANA_DASHBOARD_URL=https://your-org.grafana.net/d/xxxxxx/dashboard-name
+
+# ── Playbooks ─────────────────────────────────────────────────────────────────
+# Directory containing playbook YAML files. Defaults to ./playbooks (relative to project root).
+# In Docker this resolves to /app/playbooks which is included in the image.
+# PLAYBOOKS_DIR=/app/playbooks
+
+# ── Webhook Security ─────────────────────────────────────────────────────────
+# Optional HMAC-SHA256 secret for validating Grafana webhook signatures.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+# WEBHOOK_SECRET=your-secret-here

--- a/config.py
+++ b/config.py
@@ -4,12 +4,8 @@ from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
-# Initialize Environment Variables
 load_dotenv()
 
-# --- Configuration ---
-GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-GITHUB_REPO = os.getenv("GITHUB_REPO")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 EMAIL_SENDER = os.getenv("EMAIL_SENDER")
 EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
@@ -21,7 +17,21 @@ GRAFANA_TOKEN = os.getenv("GRAFANA_TOKEN")
 GRAFANA_DASHBOARD_URL = os.getenv("GRAFANA_DASHBOARD_URL")
 EMAIL_RECIPIENTS = [r.strip() for r in os.getenv("EMAIL_RECIPIENTS", "").split(",") if r.strip()]
 
-# Check required environment variables to prevent crashes
-missing_envs = [name for name in ["GITHUB_TOKEN", "GITHUB_REPO", "GEMINI_API_KEY", "EMAIL_SENDER", "EMAIL_PASSWORD", "GRAFANA_TOKEN", "GRAFANA_URL"] if not os.getenv(name)]
-if missing_envs:
-    logger.warning(f"The following essential environment variables are missing: {', '.join(missing_envs)}")
+# Optional — when set, webhook requests must carry a matching HMAC-SHA256 signature.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET")
+
+_REQUIRED = [
+    "GEMINI_API_KEY",
+    "EMAIL_SENDER",
+    "EMAIL_PASSWORD",
+    "GRAFANA_TOKEN",
+    "GRAFANA_URL",
+]
+
+_missing = [name for name in _REQUIRED if not os.getenv(name)]
+if _missing:
+    raise RuntimeError(
+        f"Missing required environment variables: {', '.join(_missing)}. "
+        "Copy .env.example to .env and fill in the values."
+    )

--- a/core/engine.py
+++ b/core/engine.py
@@ -2,7 +2,7 @@ import os
 import re
 import logging
 from config import GRAFANA_DASHBOARD_URL
-from services.github import load_playbook
+from services.playbooks import load_playbook
 from services.grafana import capture_dashboard, fetch_grafana_metric
 from services.ai import get_ai_analysis
 from services.email import send_email_report

--- a/playbooks/diskspacelow.yaml
+++ b/playbooks/diskspacelow.yaml
@@ -1,0 +1,17 @@
+name: DiskSpaceLow
+instruction: |
+  You are an SRE responding to a low disk space alert. Identify which mount point
+  is filling up, likely causes (log accumulation, large files, backup overflow),
+  and recommend immediate cleanup steps and monitoring improvements.
+actions:
+  - type: fetch_metrics
+    target: Disk Usage
+    query: "100 - ((node_filesystem_avail_bytes{mountpoint='/'} / node_filesystem_size_bytes{mountpoint='/'}) * 100)"
+
+  - type: fetch_metrics
+    target: Disk Free (GB)
+    query: "node_filesystem_avail_bytes{mountpoint='/'} / 1024 / 1024 / 1024"
+
+  - type: ai_analysis
+
+  - type: send_notification

--- a/playbooks/highcpuusage.yaml
+++ b/playbooks/highcpuusage.yaml
@@ -1,0 +1,19 @@
+name: HighCPUUsage
+instruction: |
+  You are an SRE responding to a high CPU alert. Analyze the metrics and screenshot,
+  identify the likely cause (runaway process, load spike, misconfigured autoscaler),
+  and recommend immediate remediation steps and a longer-term fix.
+actions:
+  - type: capture_dashboard_screenshot
+
+  - type: fetch_metrics
+    target: CPU Usage
+    query: "100 - (avg(rate(node_cpu_seconds_total{mode='idle'}[5m])) * 100)"
+
+  - type: fetch_metrics
+    target: Load Average
+    query: "node_load1"
+
+  - type: ai_analysis
+
+  - type: send_notification

--- a/playbooks/highmemoryusage.yaml
+++ b/playbooks/highmemoryusage.yaml
@@ -1,0 +1,19 @@
+name: HighMemoryUsage
+instruction: |
+  You are an SRE responding to a high memory usage alert. Analyze the metrics,
+  identify memory leaks or unexpected growth, and recommend immediate actions
+  (e.g. restart, heap dump) and longer-term fixes.
+actions:
+  - type: capture_dashboard_screenshot
+
+  - type: fetch_metrics
+    target: Memory Usage
+    query: "100 * (1 - ((avg_over_time(node_memory_MemFree_bytes[5m]) + avg_over_time(node_memory_Cached_bytes[5m]) + avg_over_time(node_memory_Buffers_bytes[5m])) / avg_over_time(node_memory_MemTotal_bytes[5m])))"
+
+  - type: fetch_metrics
+    target: Available Memory
+    query: "node_memory_MemAvailable_bytes / 1024 / 1024"
+
+  - type: ai_analysis
+
+  - type: send_notification

--- a/playbooks/servicedown.yaml
+++ b/playbooks/servicedown.yaml
@@ -1,0 +1,19 @@
+name: ServiceDown
+instruction: |
+  You are an SRE responding to a service-down alert. Analyze the error rate and
+  uptime metrics, determine if this is a crash, OOM, deployment rollout issue,
+  or dependency failure, and provide immediate recovery steps.
+actions:
+  - type: capture_dashboard_screenshot
+
+  - type: fetch_metrics
+    target: HTTP 5xx Rate
+    query: "sum(rate(http_requests_total{status=~'5..'}[5m]))"
+
+  - type: fetch_metrics
+    target: Service Uptime
+    query: "up{job='your_service'}"
+
+  - type: ai_analysis
+
+  - type: send_notification

--- a/services/playbooks.py
+++ b/services/playbooks.py
@@ -1,0 +1,23 @@
+import os
+import yaml
+import logging
+
+logger = logging.getLogger(__name__)
+
+PLAYBOOKS_DIR = os.getenv("PLAYBOOKS_DIR", os.path.join(os.path.dirname(__file__), "..", "playbooks"))
+
+
+def load_playbook(alert_name: str) -> dict | None:
+    """Load a playbook YAML from the local playbooks directory."""
+    file_name = alert_name.replace(" ", "_").lower() + ".yaml"
+    path = os.path.join(PLAYBOOKS_DIR, file_name)
+
+    try:
+        with open(path, "r") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        logger.warning(f"No playbook found for '{alert_name}' at {path}")
+        return None
+    except yaml.YAMLError as e:
+        logger.error(f"Failed to parse playbook {path}: {e}")
+        return None


### PR DESCRIPTION
Replaces GitHub API-based playbook fetching with a local directory loader. 

Playbooks now live in `playbooks/` and are bundled into the Docker image via the existing `COPY . .` step — no GitHub token or repo config needed.